### PR TITLE
Disable datapack temporarily

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -15,4 +15,5 @@ BreakBeforeConceptDeclarations: Always
 BreakTemplateDeclarations: Yes
 ColumnLimit: 80
 AllowShortFunctionsOnASingleLine: Empty
+AllowShortLambdasOnASingleLine: Empty
 AlignEscapedNewlines: DontAlign

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,9 +76,9 @@ add_library(datagui SHARED
 
   src/gui.cpp
 
-  src/datapack/edit.cpp
-  src/datapack/reader.cpp
-  src/datapack/writer.cpp
+  # src/datapack/edit.cpp
+  # src/datapack/reader.cpp
+  # src/datapack/writer.cpp
 )
 target_link_libraries(datagui
     PUBLIC GL glfw GLEW ${CMAKE_DL_LIBS} ${FREETYPE_LIBRARIES} datapack

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -12,8 +12,8 @@ create_example(gui lists)
 create_example(gui popups)
 create_example(gui splits)
 
-create_example(datapack datapack)
-create_example(datapack datapack_2)
+# create_example(datapack datapack)
+# create_example(datapack datapack_2)
 
 create_example(canvas canvas2d)
 create_example(canvas canvas3d)

--- a/examples/gui/lists.cpp
+++ b/examples/gui/lists.cpp
@@ -38,7 +38,9 @@ void edit_list_1(datagui::Gui& gui) {
         auto iter = std::find_if(
             persons->begin(),
             persons->end(),
-            [name](const auto& person) { return person.name == name; });
+            [name](const auto& person) {
+              return person.name == name;
+            });
         assert(iter != persons->end());
         persons.mut().erase(iter);
       });
@@ -71,7 +73,9 @@ void edit_list_1(datagui::Gui& gui) {
       auto existing = std::find_if(
           persons->begin(),
           persons->end(),
-          [&](const Person& person) { return person.name == *new_name; });
+          [&](const Person& person) {
+            return person.name == *new_name;
+          });
       if (existing != persons->end()) {
         error.set("Person with name '" + *new_name + "' already exists");
         return;
@@ -103,14 +107,18 @@ void edit_list_2(datagui::Gui& gui) {
       gui.key(key);
       if (gui.group()) {
         gui.text_input("", {});
-        gui.button("Remove", [=]() { keys.mut().remove(key); });
+        gui.button("Remove", [=]() {
+          keys.mut().remove(key);
+        });
         gui.end();
       }
     }
     gui.end();
   }
   if (gui.group()) {
-    gui.button("Push", [=]() { keys.mut().append(); });
+    gui.button("Push", [=]() {
+      keys.mut().append();
+    });
     gui.end();
   }
   gui.end();

--- a/examples/gui/popups.cpp
+++ b/examples/gui/popups.cpp
@@ -12,7 +12,9 @@ int main() {
   while (gui.running()) {
     if (gui.group()) {
       auto window_1_open = gui.variable<bool>(false);
-      gui.button("Open window 1", [=]() { window_1_open.set(true); });
+      gui.button("Open window 1", [=]() {
+        window_1_open.set(true);
+      });
 
       gui.args().bg_color(datagui::Color::Hsl(180, 0.7, 0.7));
       if (gui.popup(window_1_open, "Floating 1", 700, 100)) {
@@ -27,7 +29,9 @@ int main() {
       }
 
       auto window_2_open = gui.variable<bool>(false);
-      gui.button("Open window 2", [=]() { window_2_open.set(true); });
+      gui.button("Open window 2", [=]() {
+        window_2_open.set(true);
+      });
 
       gui.args().bg_color(datagui::Color::Hsl(0, 0.7, 0.7));
       if (gui.popup(window_2_open, "Floating 2", 300, 150)) {

--- a/examples/gui/splits.cpp
+++ b/examples/gui/splits.cpp
@@ -14,8 +14,12 @@ int main() {
             gui.text_box(std::to_string(*counter));
             gui.end();
           }
-          gui.button("Increment", [counter]() { counter.mut()++; });
-          gui.button("Decrement", [counter]() { counter.mut()--; });
+          gui.button("Increment", [counter]() {
+            counter.mut()++;
+          });
+          gui.button("Decrement", [counter]() {
+            counter.mut()--;
+          });
           gui.end();
         }
         gui.args().grid(-1, 3);
@@ -39,7 +43,9 @@ int main() {
         if (gui.popup(popup_open, "Popup", 200, 200)) {
           auto counter = gui.variable<int>(0);
           gui.text_box("Popup " + std::to_string(*counter));
-          gui.button("Increment", [=]() { counter.mut()++; });
+          gui.button("Increment", [=]() {
+            counter.mut()++;
+          });
           gui.end();
         }
 
@@ -51,7 +57,9 @@ int main() {
           if (gui.dropdown("Two - Click!")) {
             gui.text_box("Item 0");
             gui.text_box("Item 1");
-            gui.button("Spawn popup", [=]() { popup_open.set(true); });
+            gui.button("Spawn popup", [=]() {
+              popup_open.set(true);
+            });
             gui.text_box("Item 3");
             gui.end();
           }

--- a/include/datagui/color.hpp
+++ b/include/datagui/color.hpp
@@ -59,8 +59,8 @@ public:
 
 } // namespace datagui
 
-namespace datapack {
+namespace dpack {
 
-DATAPACK_DECL(datagui::Color)
+DPACK_DECL(datagui::Color)
 
-} // namespace datapack
+} // namespace dpack

--- a/include/datagui/datapack/edit.hpp
+++ b/include/datagui/datapack/edit.hpp
@@ -8,6 +8,6 @@ class Gui;
 void datapack_edit(
     Gui& gui,
     const std::string& next_label,
-    const datapack::Schema& schema);
+    const dpack::Schema& schema);
 
 } // namespace datagui

--- a/include/datagui/datapack/reader.hpp
+++ b/include/datagui/datapack/reader.hpp
@@ -5,11 +5,11 @@
 
 namespace datagui {
 
-class GuiReader : public datapack::Reader {
+class GuiReader : public dpack::Reader {
 public:
   GuiReader(ConstElementPtr node) : node(node) {}
 
-  void number(datapack::NumberType type, void* value) override;
+  void number(dpack::NumberType type, void* value) override;
   bool boolean() override;
   const char* string() override;
   int enumerate(const std::span<const char*>& labels) override;
@@ -29,8 +29,8 @@ public:
   void tuple_next() override;
   void tuple_end() override;
 
-  void list_begin() override;
-  bool list_next() override;
+  size_t list_begin() override;
+  void list_next() override;
   void list_end() override;
 
 private:
@@ -44,7 +44,7 @@ private:
 };
 
 template <typename T>
-void datapack_read(ConstElementPtr node, T& value) {
+void dpack_read(ConstElementPtr node, T& value) {
   GuiReader reader(node);
   reader.value(value);
   assert(reader.valid());

--- a/include/datagui/datapack/writer.hpp
+++ b/include/datagui/datapack/writer.hpp
@@ -8,12 +8,12 @@
 namespace datagui {
 
 class Gui;
-class GuiWriter : public datapack::Writer {
+class GuiWriter : public dpack::Writer {
 public:
   GuiWriter(Gui& gui, const std::string& root_label) :
       gui(gui), next_label(root_label) {}
 
-  void number(datapack::NumberType type, const void* value) override;
+  void number(dpack::NumberType type, const void* value) override;
   void boolean(bool value) override;
   void string(const char*) override;
   void enumerate(int value, const std::span<const char*>& labels) override;
@@ -33,7 +33,7 @@ public:
   void tuple_next() override;
   void tuple_end() override;
 
-  void list_begin() override;
+  void list_begin(size_t size) override;
   void list_next() override;
   void list_end() override;
 

--- a/include/datagui/element/tree.hpp
+++ b/include/datagui/element/tree.hpp
@@ -299,6 +299,16 @@ public:
       return ElementPtr_(tree, parent_, tree->elements[index].prev);
     }
 
+    size_t size() const {
+      size_t size = 0;
+      size_t iter = index;
+      while (iter != -1) {
+        iter = tree->elements[iter].next;
+        size++;
+      }
+      return size;
+    }
+
     std::conditional_t<IsConst, const State&, State&> state() const {
       assert(tree && index != -1);
       return tree->elements[index].state;

--- a/include/datagui/gui.hpp
+++ b/include/datagui/gui.hpp
@@ -4,8 +4,6 @@
 #include <GLFW/glfw3.h>
 
 #include "datagui/datapack/edit.hpp"
-#include "datagui/datapack/reader.hpp"
-#include "datagui/datapack/writer.hpp"
 #include "datagui/element/args.hpp"
 #include "datagui/element/system.hpp"
 #include "datagui/element/tree.hpp"
@@ -58,7 +56,9 @@ public:
 
   void checkbox(bool initial_value, const std::function<void(bool)>& callback);
   void checkbox(bool& value) {
-    checkbox(value, [&value](bool new_value) { value = new_value; });
+    checkbox(value, [&value](bool new_value) {
+      value = new_value;
+    });
   }
   void checkbox(const Var<bool>& var);
 
@@ -89,7 +89,9 @@ public:
       int initial_choice,
       const std::function<void(int)>& callback);
   void select(const std::vector<std::string>& choices, int& choice) {
-    select(choices, choice, [&choice](int new_choice) { choice = new_choice; });
+    select(choices, choice, [&choice](int new_choice) {
+      choice = new_choice;
+    });
   }
   void select(const std::vector<std::string>& choices, const Var<int>& choice);
 
@@ -134,7 +136,9 @@ public:
   void number_input(const Var<T>& var);
   template <typename T>
   void number_input(T& value) {
-    number_input(value, [&value](T new_value) { value = new_value; });
+    number_input(value, [&value](T new_value) {
+      value = new_value;
+    });
   }
 
   void text_box(const std::string& text);
@@ -193,8 +197,9 @@ public:
     if (!group()) {
       return;
     }
-    auto schema = variable<datapack::Schema>(
-        []() { return datapack::Schema::make<T>(); });
+    auto schema = variable<dpack::Schema>([]() {
+      return dpack::Schema::make<T>();
+    });
     if (is_new) {
       datapack_write(*this, label, initial_value);
     } else {
@@ -216,8 +221,9 @@ public:
     }
 
     auto var_version = variable<int>(0);
-    auto schema = variable<datapack::Schema>(
-        []() { return datapack::Schema::make<T>(); });
+    auto schema = variable<dpack::Schema>([]() {
+      return dpack::Schema::make<T>();
+    });
 
     if (var.version() != var_version.mut_internal() || is_new) {
       var_version.mut_internal() = var.version();
@@ -235,21 +241,22 @@ public:
   }
 
   template <typename T>
-  requires datapack::writeable<T> && datapack::readable<T>
+  requires dpack::supported<T>
   void edit(const std::string& label, T& value) {
     bool is_new = !current;
     args_.tight();
     if (!group()) {
       return;
     }
-    auto schema = variable<datapack::Schema>(
-        [&]() { return datapack::Schema::make<T>(); });
+    auto schema = variable<dpack::Schema>([&]() {
+      return dpack::Schema::make<T>();
+    });
     if (is_new) {
       datapack_write(*this, label, value);
     } else {
       datapack_edit(*this, label, *schema);
       auto node_capture = current.prev();
-      value = datapack_read<T>(node_capture);
+      datapack_read<T>(node_capture, value);
     }
     end();
   }

--- a/include/datagui/gui.hpp
+++ b/include/datagui/gui.hpp
@@ -186,6 +186,7 @@ public:
   void trigger(Trigger& trigger);
   void retrigger();
 
+#if 0
   template <typename T>
   requires std::is_default_constructible_v<T>
   void edit(
@@ -260,6 +261,7 @@ public:
     }
     end();
   }
+#endif
 
   Args& args() {
     return args_;

--- a/include/datagui/viewport/plotter.hpp
+++ b/include/datagui/viewport/plotter.hpp
@@ -6,6 +6,7 @@
 #include "datagui/visual/text_2d_shader.hpp"
 #include <functional>
 #include <vector>
+#include <optional>
 
 namespace datagui {
 

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -116,8 +116,8 @@ Color Color::multiply(float factor) const {
 
 } // namespace datagui
 
-namespace datapack {
+namespace dpack {
 
-DATAPACK_DEF(datagui::Color, r, g, b, a)
+DPACK_DEF(datagui::Color, r, g, b, a)
 
-} // namespace datapack
+} // namespace dpack

--- a/src/datapack/edit.cpp
+++ b/src/datapack/edit.cpp
@@ -7,8 +7,8 @@ namespace datagui {
 void datapack_edit(
     Gui& gui,
     const std::string& root_label,
-    const datapack::Schema& schema) {
-  std::stack<datapack::Schema::Iterator> stack;
+    const dpack::Schema& schema) {
+  std::stack<dpack::Schema::Iterator> stack;
   struct ListState {
     Var<KeyList> keys;
     std::size_t i;
@@ -72,7 +72,7 @@ void datapack_edit(
               break;
             }
             if (!iter.variant_next()) {
-              throw datapack::SchemaError("Expected VariantNext");
+              throw dpack::SchemaError("Expected VariantNext");
             }
             iter = iter.next().skip();
           }
@@ -99,7 +99,7 @@ void datapack_edit(
           }
           auto object_next = iter.object_next();
           if (!object_next) {
-            throw datapack::SchemaError("Expected ObjectNext");
+            throw dpack::SchemaError("Expected ObjectNext");
           }
           next_label = object_next->key;
           have_next = true;
@@ -119,7 +119,7 @@ void datapack_edit(
           continue;
         }
         if (!iter.tuple_next()) {
-          throw datapack::SchemaError("Expected TupleNext");
+          throw dpack::SchemaError("Expected TupleNext");
         }
         iter = iter.next();
         break;
@@ -145,7 +145,7 @@ void datapack_edit(
 
     if (auto object_begin = iter.object_begin()) {
       if (object_begin->constraint) {
-        if (std::get_if<datapack::ConstraintObjectColor>(
+        if (std::get_if<dpack::ConstraintObjectColor>(
                 &(*object_begin->constraint))) {
           if (in_object) {
             gui.text_box(label);
@@ -218,11 +218,11 @@ void datapack_edit(
         iter = iter.next();
         while (iter != schema.end()) {
           if (iter.variant_end()) {
-            throw datapack::SchemaError("Didn't find matching VariantNext");
+            throw dpack::SchemaError("Didn't find matching VariantNext");
           }
           auto variant_next = iter.variant_next();
           if (!variant_next) {
-            throw datapack::SchemaError("Expected VariantNext");
+            throw dpack::SchemaError("Expected VariantNext");
           }
           if (variant_next->index == *choice) {
             break;
@@ -230,7 +230,7 @@ void datapack_edit(
           iter = iter.next().skip();
         }
         if (iter == schema.end()) {
-          throw datapack::SchemaError("Unexpected end of schema");
+          throw dpack::SchemaError("Unexpected end of schema");
         }
         assert(iter.variant_next());
         stack.push(iter);
@@ -249,7 +249,7 @@ void datapack_edit(
 
     if (auto number = iter.number()) {
       if (number->constraint) {
-        if (auto range = std::get_if<datapack::ConstraintNumberRange>(
+        if (auto range = std::get_if<dpack::ConstraintNumberRange>(
                 &(*number->constraint))) {
           gui.slider(range->lower, range->lower, range->upper, {});
           iter = iter.next();
@@ -257,25 +257,25 @@ void datapack_edit(
         }
       }
       switch (number->type) {
-      case datapack::NumberType::I32:
+      case dpack::NumberType::I32:
         gui.number_input<std::int32_t>(0, {});
         break;
-      case datapack::NumberType::I64:
+      case dpack::NumberType::I64:
         gui.number_input<std::int64_t>(0, {});
         break;
-      case datapack::NumberType::U32:
+      case dpack::NumberType::U32:
         gui.number_input<std::uint32_t>(0, {});
         break;
-      case datapack::NumberType::U64:
+      case dpack::NumberType::U64:
         gui.number_input<std::uint64_t>(0, {});
         break;
-      case datapack::NumberType::F32:
+      case dpack::NumberType::F32:
         gui.number_input<float>(0, {});
         break;
-      case datapack::NumberType::F64:
+      case dpack::NumberType::F64:
         gui.number_input<double>(0, {});
         break;
-      case datapack::NumberType::U8:
+      case dpack::NumberType::U8:
         gui.number_input<std::uint8_t>(0, {});
         break;
       }

--- a/src/datapack/edit.cpp
+++ b/src/datapack/edit.cpp
@@ -29,7 +29,9 @@ void datapack_edit(
         if (state.i != 0) {
           auto keys = state.keys;
           std::size_t key = (*keys)[state.i - 1];
-          gui.button("Remove", [=]() { keys.mut().remove(key); });
+          gui.button("Remove", [=]() {
+            keys.mut().remove(key);
+          });
           gui.end();
         }
 
@@ -45,7 +47,9 @@ void datapack_edit(
         if (state.i == state.keys->size()) {
           gui.end();
           auto keys_var = state.keys;
-          gui.button("new", [keys_var]() { keys_var.mut().append(); });
+          gui.button("new", [keys_var]() {
+            keys_var.mut().append();
+          });
           gui.end();
           stack.pop();
           list_stack.pop();
@@ -181,7 +185,9 @@ void datapack_edit(
           iter = iter.next();
           continue;
         }
-        gui.button("new", [keys]() { keys.mut().append(); });
+        gui.button("new", [keys]() {
+          keys.mut().append();
+        });
         gui.end();
       }
       iter = iter.next().skip();

--- a/src/datapack/reader.cpp
+++ b/src/datapack/reader.cpp
@@ -15,90 +15,92 @@ T number_from_string(const std::string& string) {
   return value;
 }
 
-void GuiReader::number(datapack::NumberType type, void* value) {
+void GuiReader::number(dpack::NumberType type, void* value) {
   assert(node);
   if (in_color) {
     switch (type) {
-    case datapack::NumberType::I32:
+    case dpack::NumberType::I32:
       *(std::int32_t*)value = color.data[color_i - 1] * 255;
       break;
-    case datapack::NumberType::I64:
+    case dpack::NumberType::I64:
       *(std::int64_t*)value = color.data[color_i - 1] * 255;
       break;
-    case datapack::NumberType::U32:
+    case dpack::NumberType::U32:
       *(std::int32_t*)value = color.data[color_i - 1] * 255;
       break;
-    case datapack::NumberType::U64:
+    case dpack::NumberType::U64:
       *(std::uint64_t*)value = color.data[color_i - 1] * 255;
       break;
-    case datapack::NumberType::F32:
+    case dpack::NumberType::F32:
       *(float*)value = color.data[color_i - 1];
       break;
-    case datapack::NumberType::F64:
+    case dpack::NumberType::F64:
       *(double*)value = color.data[color_i - 1];
       break;
-    case datapack::NumberType::U8:
+    case dpack::NumberType::U8:
       *(std::uint8_t*)value = color.data[color_i - 1] * 255;
       break;
     }
     return;
   }
-  if (auto constraint = get_constraint<datapack::ConstraintNumber>()) {
+#if 0
+  if (auto constraint = get_constraint<dpack::ConstraintNumber>()) {
     if (auto range =
-            std::get_if<datapack::ConstraintNumberRange>(&(*constraint))) {
+            std::get_if<dpack::ConstraintNumberRange>(&(*constraint))) {
       assert(node.type() == Type::Slider);
       double input = node.slider().value;
       switch (type) {
-      case datapack::NumberType::I32:
+      case dpack::NumberType::I32:
         *(std::int32_t*)value = input;
         break;
-      case datapack::NumberType::I64:
+      case dpack::NumberType::I64:
         *(std::int64_t*)value = input;
         break;
-      case datapack::NumberType::U32:
+      case dpack::NumberType::U32:
         *(std::uint32_t*)value = input;
         break;
-      case datapack::NumberType::U64:
+      case dpack::NumberType::U64:
         *(std::uint64_t*)value = input;
         break;
-      case datapack::NumberType::U8:
+      case dpack::NumberType::U8:
         *(std::uint8_t*)value = input;
         break;
-      case datapack::NumberType::F32:
+      case dpack::NumberType::F32:
         *(float*)value = input;
         break;
-      case datapack::NumberType::F64:
+      case dpack::NumberType::F64:
         *(double*)value = input;
         break;
       }
       return;
     }
   }
+#endif
 
   assert(node.type() == Type::TextInput);
 
   const auto& text = node.text_input().text;
 
   switch (type) {
-  case datapack::NumberType::I32:
+  case dpack::NumberType::I32:
     *(std::int32_t*)value = number_from_string<std::int32_t>(text);
     break;
-  case datapack::NumberType::I64:
+  case dpack::NumberType::I64:
     *(std::int64_t*)value = number_from_string<std::int64_t>(text);
     break;
-  case datapack::NumberType::U32:
+  case dpack::NumberType::U32:
     *(std::uint32_t*)value = number_from_string<std::uint32_t>(text);
     break;
-  case datapack::NumberType::U64:
+  case dpack::NumberType::U64:
     *(std::uint64_t*)value = number_from_string<std::uint64_t>(text);
     break;
-  case datapack::NumberType::U8:
+  case dpack::NumberType::U8:
     *(std::uint8_t*)value = number_from_string<std::uint8_t>(text);
     break;
-  case datapack::NumberType::F32:
+  case dpack::NumberType::F32:
     *(float*)value = number_from_string<float>(text);
     break;
-  case datapack::NumberType::F64:
+  case dpack::NumberType::F64:
     *(double*)value = number_from_string<double>(text);
     break;
   }
@@ -122,8 +124,8 @@ int GuiReader::enumerate(const std::span<const char*>& labels) {
 std::span<const std::uint8_t> GuiReader::binary() {
   assert(node && node.type() == Type::TextInput);
   try {
-    binary_temp = datapack::base64_decode(node.text_input().text);
-  } catch (const datapack::Base64Exception&) {
+    binary_temp = dpack::base64_decode(node.text_input().text);
+  } catch (const dpack::Base64Exception&) {
     // TODO: Handle text input constraints internally
     binary_temp.clear();
   }
@@ -164,8 +166,9 @@ void GuiReader::variant_end() {
 }
 
 void GuiReader::object_begin() {
-  if (auto constraint = get_constraint<datapack::ConstraintObject>()) {
-    if (std::get_if<datapack::ConstraintObjectColor>(&(*constraint))) {
+#if 0
+  if (auto constraint = get_constraint<dpack::ConstraintObject>()) {
+    if (std::get_if<dpack::ConstraintObjectColor>(&(*constraint))) {
       assert(node && node.type() == Type::ColorPicker);
       in_color = true;
       color = node.color_picker().value;
@@ -173,6 +176,7 @@ void GuiReader::object_begin() {
       return;
     }
   }
+#endif
   assert(node.type() == Type::Collapsable);
   node = node.child();
   assert(node);
@@ -247,7 +251,7 @@ void GuiReader::tuple_end() {
   assert(node);
 }
 
-void GuiReader::list_begin() {
+size_t GuiReader::list_begin() {
   // List =
   // collapsable      # List wrapper
   //   group          # Items wrapper
@@ -263,23 +267,24 @@ void GuiReader::list_begin() {
   // list wrapper -> items wrapper -> item 0 wrapper
   node = node.child().child();
   at_object_begin = true;
+
+  return node.parent().size();
 }
 
-bool GuiReader::list_next() {
+void GuiReader::list_next() {
   if (!at_object_begin) {
     // item (i-1) content -> item i wrapper
     node = node.parent().next();
   }
   at_object_begin = false;
   if (!node) {
-    return false;
+    throw std::runtime_error("Incorrect number of tree nodes");
   }
   assert(node.type() == Type::Group);
 
   // item i wrapper -> item i content
   node = node.child();
   assert(node);
-  return true;
 }
 
 void GuiReader::list_end() {

--- a/src/datapack/writer.cpp
+++ b/src/datapack/writer.cpp
@@ -4,30 +4,30 @@
 
 namespace datagui {
 
-void GuiWriter::number(datapack::NumberType type, const void* value) {
+void GuiWriter::number(dpack::NumberType type, const void* value) {
   if (in_color) {
     float& output = color.data[color_i - 1];
     std::string value_str;
     switch (type) {
-    case datapack::NumberType::I32:
+    case dpack::NumberType::I32:
       output = double(*(std::int32_t*)value) / 255;
       break;
-    case datapack::NumberType::I64:
+    case dpack::NumberType::I64:
       output = double(*(std::int64_t*)value) / 255;
       break;
-    case datapack::NumberType::U32:
+    case dpack::NumberType::U32:
       output = double(*(std::uint32_t*)value) / 255;
       break;
-    case datapack::NumberType::U64:
+    case dpack::NumberType::U64:
       output = double(*(std::uint64_t*)value) / 255;
       break;
-    case datapack::NumberType::U8:
+    case dpack::NumberType::U8:
       output = double(*(std::uint8_t*)value) / 255;
       break;
-    case datapack::NumberType::F32:
+    case dpack::NumberType::F32:
       output = *(float*)value;
       break;
-    case datapack::NumberType::F64:
+    case dpack::NumberType::F64:
       output = *(double*)value;
       break;
     }
@@ -36,46 +36,47 @@ void GuiWriter::number(datapack::NumberType type, const void* value) {
 
   make_label();
 
-  if (auto constraint = get_constraint<datapack::ConstraintNumber>()) {
+#if 0
+  if (auto constraint = get_constraint<dpack::ConstraintNumber>()) {
     if (auto range =
-            std::get_if<datapack::ConstraintNumberRange>(&(*constraint))) {
+            std::get_if<dpack::ConstraintNumberRange>(&(*constraint))) {
 
       switch (type) {
-      case datapack::NumberType::I32:
+      case dpack::NumberType::I32:
         gui.slider<std::int32_t>(
             *(std::int32_t*)value,
             range->lower,
             range->upper,
             {});
         break;
-      case datapack::NumberType::I64:
+      case dpack::NumberType::I64:
         gui.slider<std::int64_t>(
             *(std::int64_t*)value,
             range->lower,
             range->upper,
             {});
         break;
-      case datapack::NumberType::U32:
+      case dpack::NumberType::U32:
         gui.slider<std::uint32_t>(
             *(std::uint32_t*)value,
             range->lower,
             range->upper,
             {});
         break;
-      case datapack::NumberType::U64:
+      case dpack::NumberType::U64:
         gui.slider<std::uint64_t>(
             *(std::uint64_t*)value,
             range->lower,
             range->upper,
             {});
         break;
-      case datapack::NumberType::F32:
+      case dpack::NumberType::F32:
         gui.slider<float>(*(float*)value, range->lower, range->upper, {});
         break;
-      case datapack::NumberType::F64:
+      case dpack::NumberType::F64:
         gui.slider<double>(*(double*)value, range->lower, range->upper, {});
         break;
-      case datapack::NumberType::U8:
+      case dpack::NumberType::U8:
         gui.slider<std::uint8_t>(
             *(std::uint8_t*)value,
             range->lower,
@@ -86,27 +87,28 @@ void GuiWriter::number(datapack::NumberType type, const void* value) {
       return;
     }
   }
+#endif
 
   switch (type) {
-  case datapack::NumberType::I32:
+  case dpack::NumberType::I32:
     gui.number_input<std::int32_t>(*(std::int32_t*)value, {});
     break;
-  case datapack::NumberType::I64:
+  case dpack::NumberType::I64:
     gui.number_input<std::int64_t>(*(std::int64_t*)value, {});
     break;
-  case datapack::NumberType::U32:
+  case dpack::NumberType::U32:
     gui.number_input<std::uint32_t>(*(std::uint32_t*)value, {});
     break;
-  case datapack::NumberType::U64:
+  case dpack::NumberType::U64:
     gui.number_input<std::uint64_t>(*(std::uint64_t*)value, {});
     break;
-  case datapack::NumberType::U8:
+  case dpack::NumberType::U8:
     gui.number_input<std::uint8_t>(*(std::uint8_t*)value, {});
     break;
-  case datapack::NumberType::F32:
+  case dpack::NumberType::F32:
     gui.number_input<float>(*(float*)value, {});
     break;
-  case datapack::NumberType::F64:
+  case dpack::NumberType::F64:
     gui.number_input<double>(*(double*)value, {});
     break;
   }
@@ -133,7 +135,7 @@ void GuiWriter::enumerate(int value, const std::span<const char*>& labels) {
 
 void GuiWriter::binary(const std::span<const std::uint8_t>& data) {
   make_label();
-  std::string text = datapack::base64_encode(data);
+  std::string text = dpack::base64_encode(data);
   gui.text_input(text, {});
 }
 
@@ -172,14 +174,16 @@ void GuiWriter::variant_end() {
 }
 
 void GuiWriter::object_begin() {
-  if (auto constraint = get_constraint<datapack::ConstraintObject>()) {
-    if (std::get_if<datapack::ConstraintObjectColor>(&(*constraint))) {
+#if 0
+  if (auto constraint = get_constraint<dpack::ConstraintObject>()) {
+    if (std::get_if<dpack::ConstraintObjectColor>(&(*constraint))) {
       in_color = true;
       color = Color::Black();
       color_i = 0;
       return;
     }
   }
+#endif
   gui.args().grid(-1, 2);
   make_collapsable();
 }
@@ -217,7 +221,9 @@ void GuiWriter::tuple_end() {
   gui.end();
 }
 
-void GuiWriter::list_begin() {
+void GuiWriter::list_begin(size_t size) {
+  (void)size;
+
   make_collapsable();
 
   auto key_list = gui.variable<KeyList>();

--- a/src/datapack/writer.cpp
+++ b/src/datapack/writer.cpp
@@ -238,7 +238,9 @@ void GuiWriter::list_next() {
   if (state.index != 0) {
     auto keys = state.keys;
     std::size_t key = (*keys)[state.index - 1];
-    gui.button("Remove", [=]() { keys.mut().remove(key); });
+    gui.button("Remove", [=]() {
+      keys.mut().remove(key);
+    });
     gui.end();
   }
 
@@ -260,7 +262,9 @@ void GuiWriter::list_end() {
 
   if (state.index != 0) {
     std::size_t key = (*keys)[state.index - 1];
-    gui.button("Remove", [=]() { keys.mut().remove(key); });
+    gui.button("Remove", [=]() {
+      keys.mut().remove(key);
+    });
     gui.end();
   }
 
@@ -270,7 +274,9 @@ void GuiWriter::list_end() {
     keys.mut_internal().remove((*keys)[state.index]);
   }
 
-  gui.button("new", [=]() { keys.mut().append(); });
+  gui.button("new", [=]() {
+    keys.mut().append();
+  });
   gui.end();
 
   list_stack.pop();

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -129,7 +129,9 @@ void Gui::checkbox(const Var<bool>& var) {
   args_.apply(current);
   current = current.next();
 
-  checkbox.callback = [var](bool value) { var.set(value); };
+  checkbox.callback = [var](bool value) {
+    var.set(value);
+  };
   checkbox.checked = *var;
 }
 
@@ -168,7 +170,9 @@ void Gui::color_picker(const Var<Color>& var) {
   args_.apply(current);
   current = current.next();
 
-  color_picker.callback = [var](const Color& value) { var.set(value); };
+  color_picker.callback = [var](const Color& value) {
+    var.set(value);
+  };
   color_picker.value = *var;
 }
 
@@ -220,7 +224,9 @@ bool Gui::popup(
   auto& popup = current.popup();
 
   popup.title = title;
-  popup.closed_callback = [open_var]() { open_var.set(false); };
+  popup.closed_callback = [open_var]() {
+    open_var.set(false);
+  };
   popup.popup_size = Vec2(width, height);
 
   bool opened = (*open_var && !popup.open);
@@ -266,7 +272,9 @@ void Gui::select(const std::vector<std::string>& choices, const Var<int>& var) {
 
   select.choices = choices;
   select.choice = *var;
-  select.callback = [var](int value) { var.set(value); };
+  select.callback = [var](int value) {
+    var.set(value);
+  };
 }
 
 template <typename T>
@@ -292,13 +300,17 @@ void Gui::slider(
     slider.callback = callback;
   }
   if constexpr (!std::is_same_v<T, double>) {
-    slider.callback = [callback](double value) { callback(value); };
+    slider.callback = [callback](double value) {
+      callback(value);
+    };
   }
 
   if (slider.value < lower || slider.value > upper) {
     double new_value = std::clamp<double>(slider.value, lower, upper);
     slider.value = new_value;
-    misc_events.push_back([callback, new_value]() { callback(new_value); });
+    misc_events.push_back([callback, new_value]() {
+      callback(new_value);
+    });
   }
 }
 
@@ -316,12 +328,16 @@ void Gui::slider(T lower, T upper, const Var<T>& var) {
     slider.initial_value = *var;
   }
 
-  slider.callback = [var](double value) { var.set(value); };
+  slider.callback = [var](double value) {
+    var.set(value);
+  };
   slider.value = *var;
   if (slider.value < lower || slider.value > upper) {
     double new_value = std::clamp<double>(slider.value, lower, upper);
     slider.value = new_value;
-    misc_events.push_back([var, new_value]() { var.set(new_value); });
+    misc_events.push_back([var, new_value]() {
+      var.set(new_value);
+    });
   }
 }
 
@@ -418,7 +434,9 @@ void Gui::text_input(const Var<std::string>& var) {
   args_.apply(current);
   current = current.next();
 
-  text_input.callback = [var](const std::string& value) { var.set(value); };
+  text_input.callback = [var](const std::string& value) {
+    var.set(value);
+  };
   text_input.text = *var;
 }
 


### PR DESCRIPTION
I want to re-work the library to avoid doing change detection for nodes, which should greatly simplify the logic, at the expense of a slightly (likely negligible) higher runtime cost.

I've also made some changes to the datapack library, but all the corresponding datagui code will need to be re-written when re-working the library anyway, so deferring for now and disabling all datapack code so it compiles.