### PR TITLE
Deferred opening

### DIFF
--- a/examples/canvas/canvas2d.cpp
+++ b/examples/canvas/canvas2d.cpp
@@ -3,6 +3,7 @@
 
 int main() {
   dgui::Gui gui;
+  gui.open();
   using dgui::Box2;
   using dgui::Color;
   using dgui::Vec2;

--- a/examples/canvas/canvas3d.cpp
+++ b/examples/canvas/canvas3d.cpp
@@ -3,6 +3,7 @@
 
 int main() {
   dgui::Gui gui;
+  gui.open();
   using dgui::Color;
   using dgui::Euler;
   using dgui::Rot3;

--- a/examples/datapack/datapack.cpp
+++ b/examples/datapack/datapack.cpp
@@ -80,6 +80,7 @@ inline void write(Writer& writer, const Foo& foo) {
 
 int main() {
   dgui::Gui gui;
+  gui.open();
 
   while (gui.poll()) {
     gui.args().width_expand();

--- a/examples/datapack/datapack_2.cpp
+++ b/examples/datapack/datapack_2.cpp
@@ -32,6 +32,7 @@ DPACK_LABELLED_VARIANT_DEF(Shape) = {"Point", "Circle"};
 
 int main() {
   dgui::Gui gui;
+  gui.open();
 
   Shape shape;
 

--- a/examples/gui/basic.cpp
+++ b/examples/gui/basic.cpp
@@ -3,6 +3,7 @@
 
 int main() {
   dgui::Gui gui;
+  gui.open();
 
   while (gui.poll()) {
     gui.group();

--- a/examples/gui/core_elements.cpp
+++ b/examples/gui/core_elements.cpp
@@ -4,6 +4,7 @@
 
 int main() {
   dgui::Gui gui;
+  gui.open();
 
   int timer = 0;
   bool timer_paused = false;

--- a/examples/gui/extra_inputs.cpp
+++ b/examples/gui/extra_inputs.cpp
@@ -3,6 +3,7 @@
 
 int main() {
   dgui::Gui gui;
+  gui.open();
 
   while (gui.poll()) {
     gui.group();

--- a/examples/gui/lists.cpp
+++ b/examples/gui/lists.cpp
@@ -121,6 +121,7 @@ void edit_list_2(dgui::Gui& gui) {
 
 int main() {
   dgui::Gui gui;
+  gui.open();
 
   while (gui.poll()) {
     gui.group();

--- a/examples/gui/popups.cpp
+++ b/examples/gui/popups.cpp
@@ -3,6 +3,7 @@
 
 int main() {
   dgui::Gui gui;
+  gui.open();
 
   std::vector<std::string> choices;
   for (std::size_t i = 0; i < 20; i++) {

--- a/examples/gui/splits.cpp
+++ b/examples/gui/splits.cpp
@@ -2,6 +2,7 @@
 
 int main() {
   dgui::Gui gui;
+  gui.open();
   using dgui::Color;
 
   while (gui.poll()) {

--- a/examples/plotter/plotter.cpp
+++ b/examples/plotter/plotter.cpp
@@ -5,6 +5,7 @@
 
 int main() {
   dgui::Gui gui;
+  gui.open();
   using dgui::Box2;
   using dgui::Color;
   using dgui::Vec2;

--- a/examples/plotter/standalone.cpp
+++ b/examples/plotter/standalone.cpp
@@ -4,6 +4,7 @@
 
 int main() {
   dgui::Gui gui;
+  gui.open();
 
   std::vector<double> xs;
   std::vector<double> ys;

--- a/include/datagui/gui.hpp
+++ b/include/datagui/gui.hpp
@@ -29,11 +29,16 @@ class Canvas3d;
 
 class Gui {
 public:
-  Gui(const std::string& title = "datagui",
-      std::size_t width = 900,
-      std::size_t height = 600);
+  Gui();
+  ~Gui();
 
   // Setup
+
+  void open(
+      const std::string& title = "datagui",
+      std::size_t width = 900,
+      std::size_t height = 600);
+  void close();
 
   bool poll();
 

--- a/include/datagui/plot.hpp
+++ b/include/datagui/plot.hpp
@@ -10,7 +10,8 @@ inline void plot(
     std::size_t width,
     std::size_t height,
     const std::function<void(Plotter&)> plot) {
-  Gui gui(title);
+  Gui gui;
+  gui.open(title);
   while (gui.running()) {
     if (auto plotter = gui.plotter(width, height)) {
       plot(*plotter);

--- a/include/datagui/visual/window.hpp
+++ b/include/datagui/visual/window.hpp
@@ -13,11 +13,14 @@ namespace dgui {
 
 class Window {
 public:
-  Window(
+  Window();
+  ~Window();
+
+  void open(
       const std::string& title = "datagui",
       std::size_t width = 900,
       std::size_t height = 600);
-  ~Window();
+  void close();
 
   bool running() const;
   void render_begin();
@@ -51,9 +54,6 @@ public:
   }
 
 private:
-  void open();
-  void close();
-
   std::string title;
   std::size_t default_width;
   std::size_t default_height;

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -21,8 +21,18 @@ namespace dgui {
 
 using namespace std::placeholders;
 
-Gui::Gui(const std::string& title, std::size_t width, std::size_t height) :
-    window(title, width, height) {
+Gui::Gui() {}
+
+Gui::~Gui() {
+  close();
+}
+
+void Gui::open(
+    const std::string& title,
+    std::size_t width,
+    std::size_t height) {
+  window.open(title, width, height);
+
   fm = std::make_shared<FontManager>();
   theme = std::make_shared<Theme>(theme_default());
   renderer.init(fm);
@@ -51,6 +61,10 @@ Gui::Gui(const std::string& title, std::size_t width, std::size_t height) :
   for (const auto& system : systems) {
     assert(system);
   }
+}
+
+void Gui::close() {
+  window.close();
 }
 
 void Gui::move_down() {

--- a/src/visual/window.cpp
+++ b/src/visual/window.cpp
@@ -181,46 +181,36 @@ void glfw_char_callback(GLFWwindow* glfw_window, unsigned int codepoint) {
   window->text_events_.push_back(event);
 }
 
-Window::Window(
-    const std::string& title,
-    std::size_t width,
-    std::size_t height) :
-    title(title),
-    default_width(width),
-    default_height(height),
+Window::Window() :
+    title("datagui"),
+    default_width(900),
+    default_height(600),
     window(nullptr),
-    size_(width, height) {
+    size_(900, 600) {
   for (std::size_t i = 0; i < MouseButtonSize; i++) {
     mouse_button_down_[i] = false;
     mouse_down_mod_[i].ctrl = false;
     mouse_down_mod_[i].shift = false;
   }
-  open();
-  std::scoped_lock<std::shared_mutex> lock(windows_mutex);
-  windows.emplace_back(window, this);
 }
 
 Window::~Window() {
-  if (window) {
-    {
-      std::scoped_lock<std::shared_mutex> lock(windows_mutex);
-      for (auto iter = windows.begin(); iter != windows.end(); iter++) {
-        if (iter->second == this) {
-          assert(iter->first == window);
-          windows.erase(iter);
-          break;
-        }
-      }
-    }
-    close();
-  }
+  close();
 }
 
 bool Window::running() const {
   return window && !glfwWindowShouldClose(window);
 }
 
-void Window::open() {
+void Window::open(
+    const std::string& title,
+    std::size_t width,
+    std::size_t height) {
+  this->title = title;
+  default_width = width;
+  default_height = height;
+  size_ = Vec2(width, height);
+
   if (!glfwInit()) {
     throw std::runtime_error("Failed to initialize glfw");
   }
@@ -256,11 +246,25 @@ void Window::open() {
   glfwSetScrollCallback(window, glfw_scroll_callback);
   glfwSetKeyCallback(window, glfw_key_callback);
   glfwSetCharCallback(window, glfw_char_callback);
+
+  std::scoped_lock<std::shared_mutex> lock(windows_mutex);
+  windows.emplace_back(window, this);
 }
 
 void Window::close() {
   if (!window) {
     return;
+  }
+
+  {
+    std::scoped_lock<std::shared_mutex> lock(windows_mutex);
+    for (auto iter = windows.begin(); iter != windows.end(); iter++) {
+      if (iter->second == this) {
+        assert(iter->first == window);
+        windows.erase(iter);
+        break;
+      }
+    }
   }
 
   glfwMakeContextCurrent(window);

--- a/test/visual/image_shader.cpp
+++ b/test/visual/image_shader.cpp
@@ -41,6 +41,7 @@ int main() {
   using namespace dgui;
 
   Window window;
+  window.open();
   ImageShader shader;
   shader.init();
 

--- a/test/visual/mesh_shader.cpp
+++ b/test/visual/mesh_shader.cpp
@@ -4,7 +4,8 @@
 int main() {
   using namespace dgui;
 
-  Window window("mesh_shader", 800, 800);
+  Window window;
+  window.open("mesh_shader", 800, 800);
   MeshShader mesh_shader;
   mesh_shader.init();
 

--- a/test/visual/point_cloud_shader.cpp
+++ b/test/visual/point_cloud_shader.cpp
@@ -4,7 +4,8 @@
 int main() {
   using namespace dgui;
 
-  Window window("point_cloud_shader", 800, 800);
+  Window window;
+  window.open("point_cloud_shader", 800, 800);
   PointCloudShader point_cloud_shader;
   point_cloud_shader.init();
 

--- a/test/visual/shape_2d_shader.cpp
+++ b/test/visual/shape_2d_shader.cpp
@@ -5,6 +5,7 @@ int main() {
   using namespace dgui;
 
   Window window;
+  window.open();
   Shape2dShader shader;
   shader.init();
 

--- a/test/visual/shape_3d_shader.cpp
+++ b/test/visual/shape_3d_shader.cpp
@@ -4,7 +4,8 @@
 int main() {
   using namespace dgui;
 
-  Window window("shape_3d_shader", 800, 800);
+  Window window;
+  window.open("shape_3d_shader", 800, 800);
   Shape3dShader shape_shader;
   shape_shader.init();
 

--- a/test/visual/text_2d_shader.cpp
+++ b/test/visual/text_2d_shader.cpp
@@ -5,6 +5,7 @@ int main() {
   using namespace dgui;
 
   Window window;
+  window.open();
   Text2dShader shader;
   auto fm = std::make_shared<FontManager>();
   shader.init(fm);

--- a/test/visual/uv_mesh_shader.cpp
+++ b/test/visual/uv_mesh_shader.cpp
@@ -4,7 +4,8 @@
 int main() {
   using namespace dgui;
 
-  Window window("uv_mesh_shader", 800, 800);
+  Window window;
+  window.open("uv_mesh_shader", 800, 800);
   UvMeshShader mesh_shader;
   mesh_shader.init();
 

--- a/test/visual/window.cpp
+++ b/test/visual/window.cpp
@@ -23,4 +23,13 @@ int main() {
       }
     }
   }
+
+  // Can re-open ?
+  window.close();
+  window.open();
+  while (window.running()) {
+    window.render_begin();
+    window.render_end();
+    window.poll_events();
+  }
 }

--- a/test/visual/window.cpp
+++ b/test/visual/window.cpp
@@ -5,6 +5,7 @@ int main() {
   using namespace dgui;
 
   Window window;
+  window.open();
   while (window.running()) {
     window.render_begin();
     window.render_end();


### PR DESCRIPTION
Switch to an explicit `open()` for opening the window and gui, which is required if the open is deferred after the initial construction.

There is also an explicit close() to allow manually closing (and possibly re-opening), as well as still closing in the destructor if still open.